### PR TITLE
remove metadata on item removal

### DIFF
--- a/src/main/java/me/john000708/barrels/DisplayItem.java
+++ b/src/main/java/me/john000708/barrels/DisplayItem.java
@@ -62,7 +62,10 @@ public class DisplayItem {
     }
 
     public static void removeDisplayItem(Block b) {
-        getEntity(b).ifPresent(Item::remove);
+        getEntity(b).ifPresent(item -> {
+		item.remove();
+		item.removeMetadata("no_pickup", Barrels.getInstance());
+        });
     }
 
     private static Optional<Item> getEntity(Block b) {


### PR DESCRIPTION
not removing the metadata creates a memory leak, this fixes that issue